### PR TITLE
remove redundant throw annotation

### DIFF
--- a/src/Vat/Provider/Europa.php
+++ b/src/Vat/Provider/Europa.php
@@ -43,7 +43,6 @@ class Europa implements Providable
      *
      * @return stdClass The VAT number's details.
      *
-     * @throws SoapFault
      * @throws Exception
      */
     public function getResource($sVatNumber, string $sCountryCode): stdClass


### PR DESCRIPTION
I believe SoapFault will never be thrown as it will be caught in line 57